### PR TITLE
6 fix unbalanced parenthesis exception while trying to detect sql files

### DIFF
--- a/oc_sql_helpers/normalizer.py
+++ b/oc_sql_helpers/normalizer.py
@@ -71,8 +71,24 @@ class PLSQLNormalizer():
             "object_name": [{"start": re.compile(b'"'), "end": re.compile(b'"')}],
             "literal":[
                 {"start": re.compile(b"q'(.)", flags=re.I), "end": b"%s'", 
-                    "substitutes": {b"[": b"\]", b"{": b"\}", b"<": b"\>", b"(": b"\)", b"?": b"\?", b".": b"\.", b"^": b"\^", b"$": b"\$", b"\\": b"\\\\", b"*": b"\*",
-                        b"+": b"\+", b"|": b"\|"}},
+                    "substitutes": {
+                        b"[": b"\]", 
+                        b"{": b"\}", 
+                        b"<": b"\>", 
+                        b"(": b"\)", 
+                        b"?": b"\?", 
+                        b".": b"\.", 
+                        b"^": b"\^", 
+                        b"$": b"\$", 
+                        b"\\": b"\\\\", 
+                        b"*": b"\*",
+                        b"+": b"\+", 
+                        b"|": b"\|",
+                        # there may be a closing brackets also, we have to escape them too
+                        b"]": b"\]", 
+                        b"}": b"\}", 
+                        b">": b"\>", 
+                        b")": b"\)"}},
                 {"start": re.compile(b"'", flags=re.I), "end": re.compile(b"'")}],
             "comment":[
                 {"start": re.compile(b'(\s|^)\-\-'), "end": re.compile(b'\n')},
@@ -207,6 +223,8 @@ class PLSQLNormalizer():
                 if _result and _match.start() >= _result.get("match").start():
                     # not a first inc, out of interest
                     continue
+
+                logging.log(1, "Found context: [%s], match: [%s]" % (_k, _match))
 
                 _result = {"context": _k, "match": _match, "end": self._make_reg_end(_regx, _match)}
 

--- a/oc_sql_helpers/tests/samples/is_sql/True/06.sql
+++ b/oc_sql_helpers/tests/samples/is_sql/True/06.sql
@@ -1,0 +1,11 @@
+create
+    or      
+    replace
+        procedure
+                FOO
+as
+  xy varchar(400);
+begin
+    xy := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+end;
+

--- a/oc_sql_helpers/tests/samples/normalize/results/_/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  xy varchar(400);
+begin
+    xy := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+end;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_no-comments/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_no-comments/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  xy varchar(400);
+begin
+    xy := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+end;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_no-comments_no-literals/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_no-comments_no-literals/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  xy varchar(400);
+begin
+    xy := q'))' || q'}}' || q'>>' || q']]' || q'\\' || q'//';
+end;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_no-comments_no-spaces/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_no-comments_no-spaces/017.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE PROCEDURE FOO AS xy varchar(400); begin xy := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./'; end;  /

--- a/oc_sql_helpers/tests/samples/normalize/results/_no-literals/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_no-literals/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  xy varchar(400);
+begin
+    xy := q'))' || q'}}' || q'>>' || q']]' || q'\\' || q'//';
+end;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  XY VARCHAR(400);
+BEGIN
+    XY := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+END;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  XY VARCHAR(400);
+BEGIN
+    XY := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+END;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-literals/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-literals/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  XY VARCHAR(400);
+BEGIN
+    XY := q'))' || q'}}' || q'>>' || q']]' || q'\\' || q'//';
+END;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-spaces/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-spaces/017.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE PROCEDURE FOO AS XY VARCHAR(400); BEGIN XY := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./'; END;  /

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-spaces_no-literals/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-comments_no-spaces_no-literals/017.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE PROCEDURE FOO AS XY VARCHAR(400); BEGIN XY := q'))' || q'}}' || q'>>' || q']]' || q'\\' || q'//'; END;  /

--- a/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-literals/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/results/_uppercase_no-literals/017.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE PROCEDURE FOO AS
+  XY VARCHAR(400);
+BEGIN
+    XY := q'))' || q'}}' || q'>>' || q']]' || q'\\' || q'//';
+END;
+
+
+
+/

--- a/oc_sql_helpers/tests/samples/normalize/sources/017.sql
+++ b/oc_sql_helpers/tests/samples/normalize/sources/017.sql
@@ -1,0 +1,11 @@
+create
+    or      
+    replace
+        procedure
+                FOO
+as
+  xy varchar(400);
+begin
+    xy := q').)' || q'}.}' || q'>.>' || q'].]' || q'\.\' || q'/\./';
+end;
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version="1.0.2"
+__version="1.0.3"
 
 spec = {
     "name": "oc-sql-helpers",


### PR DESCRIPTION
Fixed `unbalanced parenthesis` exception while trying to detect SQL quotation in `q')` style with any closed bracket as delimiter.
Tests added.